### PR TITLE
Fix Powdery Cabinet recipe not matching other Farmer's Delight cabinet recipes

### DIFF
--- a/src/generated/resources/data/mynethersdelight/advancements/recipes/misc/powdery_cabinet.json
+++ b/src/generated/resources/data/mynethersdelight/advancements/recipes/misc/powdery_cabinet.json
@@ -1,12 +1,12 @@
 {
   "parent": "minecraft:recipes/root",
   "criteria": {
-    "has_powdery_planks": {
+    "has_powdery_slab": {
       "conditions": {
         "items": [
           {
             "items": [
-              "mynethersdelight:powdery_planks"
+              "mynethersdelight:powdery_slab"
             ]
           }
         ]
@@ -15,20 +15,20 @@
     },
     "has_the_recipe": {
       "conditions": {
-        "recipe": "mynethersdelight:block_of_powdery_cabinet"
+        "recipe": "mynethersdelight:powdery_cabinet"
       },
       "trigger": "minecraft:recipe_unlocked"
     }
   },
   "requirements": [
     [
-      "has_powdery_planks",
+      "has_powdery_slab",
       "has_the_recipe"
     ]
   ],
   "rewards": {
     "recipes": [
-      "mynethersdelight:block_of_powdery_cabinet"
+      "mynethersdelight:powdery_cabinet"
     ]
   },
   "sends_telemetry_event": false

--- a/src/generated/resources/data/mynethersdelight/recipes/powdery_cabinet.json
+++ b/src/generated/resources/data/mynethersdelight/recipes/powdery_cabinet.json
@@ -3,16 +3,16 @@
   "category": "misc",
   "key": {
     "#": {
-      "item": "mynethersdelight:powdery_planks"
+      "item": "mynethersdelight:powdery_slab"
     },
     "X": {
-      "item": "mynethersdelight:powdery_slab"
+      "item": "mynethersdelight:powdery_trapdoor"
     }
   },
   "pattern": [
-    "#X#",
-    "# #",
-    "#X#"
+    "###",
+    "X X",
+    "###"
   ],
   "result": {
     "item": "mynethersdelight:powdery_cabinet"

--- a/src/main/java/com/soytutta/mynethersdelight/core/data/recipes/MNDCraftingRecipes.java
+++ b/src/main/java/com/soytutta/mynethersdelight/core/data/recipes/MNDCraftingRecipes.java
@@ -87,12 +87,12 @@ public class MNDCraftingRecipes {
                 .unlockedBy("has_powder_cannon", InventoryChangeTrigger.TriggerInstance.hasItems(MNDItems.POWDER_CANNON.get()))
                 .save(consumer, new ResourceLocation("mynethersdelight", "block_of_powdery_cannon"));
         ShapedRecipeBuilder.shaped(RecipeCategory.MISC,MNDBlocks.POWDERY_CABINET.get())
-                .pattern("#X#")
-                .pattern("# #")
-                .pattern("#X#")
-                .define('#', MNDItems.POWDERY_PLANKS.get()).define('X', MNDItems.POWDERY_PLANKS_SLAB.get())
-                .unlockedBy("has_powdery_planks", InventoryChangeTrigger.TriggerInstance.hasItems(MNDItems.POWDERY_PLANKS.get()))
-                .save(consumer, new ResourceLocation("mynethersdelight", "block_of_powdery_cabinet"));
+                .pattern("###")
+                .pattern("X X")
+                .pattern("###")
+                .define('#', MNDItems.POWDERY_PLANKS_SLAB.get()).define('X', MNDItems.POWDERY_TRAPDOOR.get())
+                .unlockedBy("has_powdery_slab", InventoryChangeTrigger.TriggerInstance.hasItems(MNDItems.POWDERY_PLANKS_SLAB.get()))
+                .save(consumer, new ResourceLocation("mynethersdelight", "powdery_cabinet"));
         ShapelessRecipeBuilder.shapeless(RecipeCategory.BUILDING_BLOCKS,MNDItems.POWDERY_PLANKS.get(),4)
                 .requires(MNDTags.BLOCK_OF_POWDERY)
                 .group("planks")


### PR DESCRIPTION
The Powdery Cabinet should be crafted with Slabs and Trapdoors, not Slabs and Planks. The pattern was incorrect and the file was misnamed, so I fixed that as well.