### PR TITLE
Nether Stove Crash and Depricated Tags Fix

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -15,6 +15,6 @@ mc_version=1.20.1
 
 ## Dependency Properties
 jei_version=15.0.0.12
-farmersdelight_version=5051242
+farmersdelight_version=8007609
 crafttweaker_version=14.0.6
 crafttweaker_annotations_version=3.0.0.15

--- a/src/main/java/com/soytutta/mynethersdelight/common/block/BreadLoafBlock.java
+++ b/src/main/java/com/soytutta/mynethersdelight/common/block/BreadLoafBlock.java
@@ -29,7 +29,7 @@ import net.minecraft.world.phys.BlockHitResult;
 import net.minecraft.world.phys.shapes.CollisionContext;
 import net.minecraft.world.phys.shapes.VoxelShape;
 import net.minecraftforge.event.ForgeEventFactory;
-import vectorwing.farmersdelight.common.tag.ModTags;
+import vectorwing.farmersdelight.common.tag.CommonTags;
 import vectorwing.farmersdelight.common.utility.ItemUtils;
 
 import java.util.function.Supplier;
@@ -75,7 +75,7 @@ public class BreadLoafBlock extends Block
         ItemStack heldStack = player.getItemInHand(hand);
 
         if (level.isClientSide) {
-            if (heldStack.is(ModTags.KNIVES)) {
+            if (heldStack.is(CommonTags.Items.TOOLS_KNIVES)) {
                 return InteractionResult.SUCCESS;
             }
 
@@ -88,7 +88,7 @@ public class BreadLoafBlock extends Block
             }
         }
 
-        if (heldStack.is(ModTags.KNIVES)) {
+        if (heldStack.is(CommonTags.Items.TOOLS_KNIVES)) {
             return this.cutSlice(level, pos, state, player);
         }
 

--- a/src/main/java/com/soytutta/mynethersdelight/common/block/MagmaCakeBlock.java
+++ b/src/main/java/com/soytutta/mynethersdelight/common/block/MagmaCakeBlock.java
@@ -41,7 +41,7 @@ import net.minecraft.world.phys.shapes.Shapes;
 import net.minecraft.world.phys.shapes.VoxelShape;
 import net.minecraftforge.fml.ModList;
 import vectorwing.farmersdelight.common.registry.ModDamageTypes;
-import vectorwing.farmersdelight.common.tag.ModTags;
+import vectorwing.farmersdelight.common.tag.CommonTags;
 import vectorwing.farmersdelight.common.utility.ItemUtils;
 
 import java.util.function.Supplier;
@@ -167,7 +167,7 @@ public class MagmaCakeBlock extends Block {
                 return secondCake(level, pos, state, player);
             }
 
-            if (heldStack.is(ModTags.KNIVES)) {
+            if (heldStack.is(CommonTags.Items.TOOLS_KNIVES)) {
                 return cutSlice(level, pos, state, player);
             }
 
@@ -184,7 +184,7 @@ public class MagmaCakeBlock extends Block {
             return secondCake(level, pos, state, player);
         }
 
-        if (heldStack.is(ModTags.KNIVES)) {
+        if (heldStack.is(CommonTags.Items.TOOLS_KNIVES)) {
             return cutSlice(level, pos, state, player);
         }
         return this.consumeBite(level, pos, state, player);

--- a/src/main/java/com/soytutta/mynethersdelight/common/block/PowderyCaneBlock.java
+++ b/src/main/java/com/soytutta/mynethersdelight/common/block/PowderyCaneBlock.java
@@ -40,7 +40,7 @@ import net.minecraft.world.phys.shapes.CollisionContext;
 import net.minecraft.world.phys.shapes.VoxelShape;
 import net.minecraftforge.common.ForgeHooks;
 import net.minecraftforge.common.IPlantable;
-import vectorwing.farmersdelight.common.tag.ForgeTags;
+import vectorwing.farmersdelight.common.tag.CommonTags;
 
 import java.util.Random;
 
@@ -167,7 +167,7 @@ public class PowderyCaneBlock extends BushBlock implements IPlantable, Bonemeala
         }
         if (state.getValue(LIT)) {
             ItemStack heldItem = player.getItemInHand(InteractionHand.MAIN_HAND);
-            if (!heldItem.is(ForgeTags.TOOLS_KNIVES) || !heldItem.is(net.minecraftforge.common.Tags.Items.SHEARS)) {
+            if (!heldItem.is(CommonTags.Items.TOOLS_KNIVES) || !heldItem.is(net.minecraftforge.common.Tags.Items.SHEARS)) {
                 int age = state.hasProperty(AGE) ? state.getValue(AGE) : 0;
                 explodeAndReset(level, pos, state, age);
             }
@@ -211,7 +211,7 @@ public class PowderyCaneBlock extends BushBlock implements IPlantable, Bonemeala
     public InteractionResult use(BlockState state, Level level, BlockPos pos, Player player, InteractionHand hand, BlockHitResult context) {
         ItemStack heldItem = player.getItemInHand(hand);
 
-         if (heldItem.is(ForgeTags.TOOLS_KNIVES) || heldItem.is(net.minecraftforge.common.Tags.Items.SHEARS)) {
+         if (heldItem.is(CommonTags.Items.TOOLS_KNIVES) || heldItem.is(net.minecraftforge.common.Tags.Items.SHEARS)) {
              int age = state.getValue(AGE);
              if (state.getValue(LIT)) {
                  if (age > 0) {

--- a/src/main/java/com/soytutta/mynethersdelight/common/block/PowderyCannonBlock.java
+++ b/src/main/java/com/soytutta/mynethersdelight/common/block/PowderyCannonBlock.java
@@ -31,7 +31,7 @@ import net.minecraft.world.phys.BlockHitResult;
 import net.minecraft.world.phys.HitResult;
 import net.minecraft.world.phys.Vec3;
 import net.minecraftforge.common.ForgeHooks;
-import vectorwing.farmersdelight.common.tag.ForgeTags;
+import vectorwing.farmersdelight.common.tag.CommonTags;
 
 import javax.annotation.Nullable;
 
@@ -184,7 +184,7 @@ public class PowderyCannonBlock extends BambooStalkBlock {
         }
         if (state.getValue(LIT)) {
             ItemStack heldItem = player.getItemInHand(InteractionHand.MAIN_HAND);
-            if (!heldItem.is(ForgeTags.TOOLS_KNIVES) || !heldItem.is(net.minecraftforge.common.Tags.Items.SHEARS)) {
+            if (!heldItem.is(CommonTags.Items.TOOLS_KNIVES) || !heldItem.is(net.minecraftforge.common.Tags.Items.SHEARS)) {
                 explodeAndDestroy(level, pos, state);
             }
         }
@@ -242,7 +242,7 @@ public class PowderyCannonBlock extends BambooStalkBlock {
         if (state.getValue(LIT)) {
             ItemStack heldItem = player.getItemInHand(hand);
 
-            if (heldItem.is(ForgeTags.TOOLS_KNIVES) ||heldItem.is(net.minecraftforge.common.Tags.Items.SHEARS)) {
+            if (heldItem.is(CommonTags.Items.TOOLS_KNIVES) ||heldItem.is(net.minecraftforge.common.Tags.Items.SHEARS)) {
                 heldItem.hurtAndBreak(1, player, (action) -> { action.broadcastBreakEvent(hand); });
                 int j = 3 + level.random.nextInt(6);
                 popResource(level, pos, new ItemStack(MNDItems.BULLET_PEPPER.get(), j));

--- a/src/main/java/com/soytutta/mynethersdelight/common/block/PowderyFlowerBlock.java
+++ b/src/main/java/com/soytutta/mynethersdelight/common/block/PowderyFlowerBlock.java
@@ -27,7 +27,7 @@ import net.minecraft.world.level.block.state.properties.IntegerProperty;
 import net.minecraft.world.phys.BlockHitResult;
 import net.minecraft.world.phys.HitResult;
 import net.minecraftforge.common.ForgeHooks;
-import vectorwing.farmersdelight.common.tag.ForgeTags;
+import vectorwing.farmersdelight.common.tag.CommonTags;
 
 import java.util.Random;
 
@@ -155,7 +155,7 @@ public class PowderyFlowerBlock extends BambooSaplingBlock {
         }
         if (state.getValue(LIT)) {
             ItemStack heldItem = player.getItemInHand(InteractionHand.MAIN_HAND);
-            if (!heldItem.is(ForgeTags.TOOLS_KNIVES) || !heldItem.is(net.minecraftforge.common.Tags.Items.SHEARS)) {
+            if (!heldItem.is(CommonTags.Items.TOOLS_KNIVES) || !heldItem.is(net.minecraftforge.common.Tags.Items.SHEARS)) {
                 int age = state.hasProperty(AGE) ? state.getValue(AGE) : 0;
                 explodeAndReset(level, pos, state, age);
             }
@@ -200,7 +200,7 @@ public class PowderyFlowerBlock extends BambooSaplingBlock {
 
         if ( age == 2 && state.getValue(LIT)) {
             ItemStack heldItem = player.getItemInHand(hand);
-            if (heldItem.is(ForgeTags.TOOLS_KNIVES) ||heldItem.is(net.minecraftforge.common.Tags.Items.SHEARS)) {
+            if (heldItem.is(CommonTags.Items.TOOLS_KNIVES) ||heldItem.is(net.minecraftforge.common.Tags.Items.SHEARS)) {
                 heldItem.hurtAndBreak(1, player, (action) -> { action.broadcastBreakEvent(hand); });
                 level.playSound(null, pos, SoundEvents.SWEET_BERRY_BUSH_PICK_BERRIES, SoundSource.BLOCKS, 1.0F, 0.8F + level.random.nextFloat() * 0.4F);
                 level.destroyBlock(pos, true);

--- a/src/main/java/com/soytutta/mynethersdelight/common/block/ResurgentSoilBlock.java
+++ b/src/main/java/com/soytutta/mynethersdelight/common/block/ResurgentSoilBlock.java
@@ -164,7 +164,7 @@ public class ResurgentSoilBlock extends Block {
                 performBonemealIfPossible(aboveBlock, pos.above(), aboveState, level, 1);
             }
 
-            if (aboveState.is(ModTags.UNAFFECTED_BY_RICH_SOIL) || aboveBlock instanceof TallFlowerBlock) {
+            if (aboveState.is(ModTags.Blocks.UNAFFECTED_BY_RICH_SOIL) || aboveBlock instanceof TallFlowerBlock) {
                 return;
             }
 

--- a/src/main/java/com/soytutta/mynethersdelight/common/block/ResurgentSoilFarmlandBlock.java
+++ b/src/main/java/com/soytutta/mynethersdelight/common/block/ResurgentSoilFarmlandBlock.java
@@ -148,7 +148,7 @@ public class ResurgentSoilFarmlandBlock extends FarmBlock {
                 }
             }
 
-            if (aboveState.is(ModTags.UNAFFECTED_BY_RICH_SOIL) || aboveBlock instanceof TallFlowerBlock) {
+            if (aboveState.is(ModTags.Blocks.UNAFFECTED_BY_RICH_SOIL) || aboveBlock instanceof TallFlowerBlock) {
                 return;
             }
 

--- a/src/main/java/com/soytutta/mynethersdelight/common/block/StriderloafBlock.java
+++ b/src/main/java/com/soytutta/mynethersdelight/common/block/StriderloafBlock.java
@@ -40,7 +40,7 @@ public class StriderloafBlock extends FeastBlock {
             if (level.getBlockState(nearbyPos).getFluidState().is(FluidTags.LAVA)) {
                 return true;
             }
-            if (nearbyPos.equals(pos.below()) && level.getBlockState(nearbyPos).is(ModTags.HEAT_SOURCES)) {
+            if (nearbyPos.equals(pos.below()) && level.getBlockState(nearbyPos).is(ModTags.Blocks.HEAT_SOURCES)) {
                 return true;
             }
         }

--- a/src/main/java/com/soytutta/mynethersdelight/common/block/StuffedHoglinBlock.java
+++ b/src/main/java/com/soytutta/mynethersdelight/common/block/StuffedHoglinBlock.java
@@ -43,7 +43,7 @@ import net.minecraft.world.phys.shapes.CollisionContext;
 import net.minecraft.world.phys.shapes.Shapes;
 import net.minecraft.world.phys.shapes.VoxelShape;
 import vectorwing.farmersdelight.common.registry.ModSounds;
-import vectorwing.farmersdelight.common.tag.ModTags;
+import vectorwing.farmersdelight.common.tag.CommonTags;
 import vectorwing.farmersdelight.common.utility.TextUtils;
 
 import java.util.ArrayList;
@@ -222,7 +222,7 @@ public class StuffedHoglinBlock extends HorizontalDirectionalBlock {
         int servings = state.getValue(SERVINGS);
         ItemStack heldStack = player.getItemInHand(handIn);
         if (servings > 9) {
-            if (heldStack.is(ModTags.KNIVES)) {
+            if (heldStack.is(CommonTags.Items.TOOLS_KNIVES)) {
                 return this.cutEar(level, pos, state);
             }
 

--- a/src/main/java/com/soytutta/mynethersdelight/common/block/TrophyBlock.java
+++ b/src/main/java/com/soytutta/mynethersdelight/common/block/TrophyBlock.java
@@ -41,7 +41,7 @@ import net.minecraft.world.phys.shapes.VoxelShape;
 import net.minecraftforge.api.distmarker.Dist;
 import net.minecraftforge.api.distmarker.OnlyIn;
 import vectorwing.farmersdelight.common.registry.ModSounds;
-import vectorwing.farmersdelight.common.tag.ForgeTags;
+import vectorwing.farmersdelight.common.tag.CommonTags;
 
 import java.util.Random;
 import java.util.stream.Stream;
@@ -172,7 +172,7 @@ public class TrophyBlock extends Block implements SimpleWaterloggedBlock {
             processTrophyInteraction(level, pos, player, hand, MNDBlocks.WAXED_HOGLIN_TROPHY.get(), SoundEvents.HONEYCOMB_WAX_ON, ParticleTypes.WAX_ON, secondParticle, secondSoundEvent, useSecondEffects);
             return InteractionResult.SUCCESS;
         }
-        else if (block == MNDBlocks.WAXED_HOGLIN_TROPHY.get() && heldItem.is(ForgeTags.TOOLS_AXES)) {
+        else if (block == MNDBlocks.WAXED_HOGLIN_TROPHY.get() && heldItem.is(CommonTags.Items.TOOLS_AXES)) {
             processTrophyInteraction(level, pos, player, hand, MNDBlocks.HOGLIN_TROPHY.get(), SoundEvents.HONEYCOMB_WAX_ON, ParticleTypes.WAX_OFF, secondParticle, secondSoundEvent, useSecondEffects);
             return InteractionResult.SUCCESS;
         }
@@ -183,7 +183,7 @@ public class TrophyBlock extends Block implements SimpleWaterloggedBlock {
             processTrophyInteraction(level, pos, player, hand, MNDBlocks.HOGLIN_TROPHY.get(), SoundEvents.ZOMBIE_VILLAGER_CURE, ParticleTypes.CLOUD, secondParticle, secondSoundEvent, useSecondEffects);
             return InteractionResult.SUCCESS;
         }
-        else if (block == MNDBlocks.HOGLIN_TROPHY.get() && heldItem.is(ForgeTags.TOOLS_KNIVES)) {
+        else if (block == MNDBlocks.HOGLIN_TROPHY.get() && heldItem.is(CommonTags.Items.TOOLS_KNIVES)) {
             secondParticle = ParticleTypes.CLOUD;
             secondSoundEvent = SoundEvents.HOGLIN_HURT;
             useSecondEffects = true;
@@ -192,7 +192,7 @@ public class TrophyBlock extends Block implements SimpleWaterloggedBlock {
             popResource(level, pos, new ItemStack(Items.LEATHER, j));
             return InteractionResult.SUCCESS;
         }
-        else if (block == MNDBlocks.ZOGLIN_TROPHY.get() && heldItem.is(ForgeTags.TOOLS_KNIVES)) {
+        else if (block == MNDBlocks.ZOGLIN_TROPHY.get() && heldItem.is(CommonTags.Items.TOOLS_KNIVES)) {
             secondParticle = ParticleTypes.CLOUD;
             secondSoundEvent = SoundEvents.ZOGLIN_HURT;
             useSecondEffects = true;
@@ -215,7 +215,7 @@ public class TrophyBlock extends Block implements SimpleWaterloggedBlock {
         if (level.isClientSide()) return;
 
         ItemStack heldItem = player.getItemInHand(hand);
-        if (heldItem.is(ForgeTags.TOOLS)) {
+        if (heldItem.is(CommonTags.Items.TOOLS)) {
             heldItem.hurtAndBreak(1, player, (p) -> p.broadcastBreakEvent(hand));
         } else if (!player.getAbilities().instabuild) {
             heldItem.shrink(1);

--- a/src/main/java/com/soytutta/mynethersdelight/common/block/entity/NetherStoveBlockEntity.java
+++ b/src/main/java/com/soytutta/mynethersdelight/common/block/entity/NetherStoveBlockEntity.java
@@ -80,7 +80,7 @@ public class NetherStoveBlockEntity extends SyncedBlockEntity {
     public static void cookingTick(Level level, BlockPos pos, BlockState state, NetherStoveBlockEntity stove) {
         boolean isStoveLit = state.getValue(NetherStoveBlock.LIT);
         if (stove.isStoveBlockedAbove()) {
-            if (!ItemUtils.isInventoryEmpty(stove.inventory)) {
+            if (ItemUtils.doesInventoryHaveItems(stove.inventory)) {
                 ItemUtils.dropItems(level, pos, stove.inventory);
                 stove.inventoryChanged();
             }

--- a/src/main/java/com/soytutta/mynethersdelight/common/events/CommonEvent.java
+++ b/src/main/java/com/soytutta/mynethersdelight/common/events/CommonEvent.java
@@ -30,8 +30,8 @@ import net.minecraft.world.level.biome.Biomes;
 import net.minecraftforge.event.entity.living.*;
 import net.minecraftforge.eventbus.api.SubscribeEvent;
 import vectorwing.farmersdelight.common.registry.ModItems;
-import vectorwing.farmersdelight.common.tag.ForgeTags;
-import vectorwing.farmersdelight.common.tag.ModTags;
+import vectorwing.farmersdelight.common.tag.CommonTags;
+import vectorwing.farmersdelight.common.tag.CommonTags;
 
 import java.util.List;
 import java.util.Map;
@@ -43,11 +43,11 @@ public class CommonEvent {
         if (!event.getEntity().level().isClientSide
                 && event.getEntity() instanceof Mob mob && event.getSource() != null
                 && event.getSource().getDirectEntity() instanceof LivingEntity directSource
-                && directSource.getItemInHand(InteractionHand.MAIN_HAND).is(ForgeTags.TOOLS)) {
+                && directSource.getItemInHand(InteractionHand.MAIN_HAND).is(CommonTags.Items.TOOLS)) {
             if (directSource.getItemInHand(InteractionHand.MAIN_HAND).getEnchantmentLevel(MNDEnchantments.HUNTING.get()) > 0
                     && (mob.getMaxHealth() < 150.0F || mob.getType().is(MNDTags.SPECIAL_HUNT))
                     && (((directSource.hasEffect(MobEffects.LUCK) || directSource.hasEffect(MobEffects.UNLUCK)) && event.getEntity().level().random.nextFloat() < 0.6F)
-                    || directSource.getItemInHand(InteractionHand.MAIN_HAND).is(ModTags.KNIVES)
+                    || directSource.getItemInHand(InteractionHand.MAIN_HAND).is(CommonTags.Items.TOOLS_KNIVES)
                     || event.getEntity().level().random.nextFloat() < 0.4F)) {
 
                 Difficulty difficulty = event.getEntity().level().getDifficulty();
@@ -83,13 +83,13 @@ public class CommonEvent {
                 // FAILED HUNT
                 if ((event.getEntity().level().random.nextFloat() < FailProbability
                         || (mob.isBaby() && event.getEntity().level().random.nextFloat() < 0.2F)
-                        || directSource.getItemInHand(InteractionHand.MAIN_HAND).is(ModTags.KNIVES))
+                        || directSource.getItemInHand(InteractionHand.MAIN_HAND).is(CommonTags.Items.TOOLS_KNIVES))
                         && !mob.hasEffect(MobEffects.CONFUSION)) {
 
                     if (mob instanceof Horse horse
                             && (event.getEntity().level().random.nextFloat() < (FailProbability / 2)
                             || (horse.isTamed() && event.getEntity().level().random.nextFloat() < FailProbability)
-                            || (directSource.getItemInHand(InteractionHand.MAIN_HAND).is(ModTags.KNIVES) && event.getEntity().level().random.nextFloat() < FailProbability))) {
+                            || (directSource.getItemInHand(InteractionHand.MAIN_HAND).is(CommonTags.Items.TOOLS_KNIVES) && event.getEntity().level().random.nextFloat() < FailProbability))) {
 
                         ZombieHorse zombieHorse = EntityType.ZOMBIE_HORSE.create(mob.level());
                         if (zombieHorse != null) {
@@ -125,7 +125,7 @@ public class CommonEvent {
                     if ((mob instanceof Frog || mob instanceof Bat)
                             && (event.getEntity().level().random.nextFloat() < (FailProbability / 2)
                             || (mob.level().getBiome(mob.blockPosition()).is(Biomes.SWAMP) && event.getEntity().level().random.nextFloat() < 0.3F)
-                            || (directSource.getItemInHand(InteractionHand.MAIN_HAND).is(ModTags.KNIVES) && event.getEntity().level().random.nextFloat() < 0.3F))) {
+                            || (directSource.getItemInHand(InteractionHand.MAIN_HAND).is(CommonTags.Items.TOOLS_KNIVES) && event.getEntity().level().random.nextFloat() < 0.3F))) {
 
                         Witch witch = EntityType.WITCH.create(mob.level());
                         if (witch != null) {

--- a/src/main/java/com/soytutta/mynethersdelight/common/item/ConsumableBlockItem.java
+++ b/src/main/java/com/soytutta/mynethersdelight/common/item/ConsumableBlockItem.java
@@ -84,7 +84,7 @@ public class ConsumableBlockItem extends BlockItem {
 
     @Override
     public void appendHoverText(ItemStack stack, @Nullable Level level, List<Component> tooltip, TooltipFlag isAdvanced) {
-        if (Configuration.FOOD_EFFECT_TOOLTIP.get()) {
+        if (Configuration.ENABLE_FOOD_EFFECT_TOOLTIP.get()) {
             if (this.hasCustomTooltip) {
                 MutableComponent textEmpty = TextUtils.getTranslation("tooltip." + this);
                 tooltip.add(textEmpty.withStyle(ChatFormatting.BLUE));

--- a/src/main/java/com/soytutta/mynethersdelight/common/item/HotCreamConeItem.java
+++ b/src/main/java/com/soytutta/mynethersdelight/common/item/HotCreamConeItem.java
@@ -87,7 +87,7 @@ public class HotCreamConeItem extends ConsumableItem {
     public static final List<MobEffectInstance> EFFECTS;
 
     public void appendHoverText(ItemStack stack, @Nullable Level level, List<Component> tooltip, TooltipFlag isAdvanced) {
-        if (Configuration.FOOD_EFFECT_TOOLTIP.get()) {
+        if (Configuration.ENABLE_FOOD_EFFECT_TOOLTIP.get()) {
             MutableComponent textWhenFeeding = TextUtils.getTranslation("tooltip.strider_feed.when_feeding");
             tooltip.add(textWhenFeeding.withStyle(ChatFormatting.GRAY));
 

--- a/src/main/java/com/soytutta/mynethersdelight/core/data/MNDBlockTags.java
+++ b/src/main/java/com/soytutta/mynethersdelight/core/data/MNDBlockTags.java
@@ -10,6 +10,7 @@ import net.minecraftforge.common.data.BlockTagsProvider;
 import net.minecraftforge.common.data.ExistingFileHelper;
 import vectorwing.farmersdelight.common.registry.ModBlocks;
 import vectorwing.farmersdelight.common.tag.ModTags;
+import vectorwing.farmersdelight.common.tag.CommonTags;
 
 import javax.annotation.Nullable;
 import java.util.concurrent.CompletableFuture;
@@ -22,7 +23,7 @@ public class MNDBlockTags extends BlockTagsProvider {
     protected void addTags(HolderLookup.Provider provider) {
         this.registerModTags();
         this.registerMinecraftTags();
-        this.registerForgeTags();
+        this.registerCommonTags();
         this.registerBlockMineables();
     }
 
@@ -30,7 +31,7 @@ public class MNDBlockTags extends BlockTagsProvider {
         this.tag(BlockTags.MINEABLE_WITH_SHOVEL).add(MNDBlocks.LETIOS_COMPOST.get(), MNDBlocks.RESURGENT_SOIL.get(), MNDBlocks.RESURGENT_SOIL_FARMLAND.get());
         this.tag(BlockTags.MINEABLE_WITH_PICKAXE).add(MNDBlocks.NETHER_BRICKS_CABINET.get(),MNDBlocks.RED_NETHER_BRICKS_CABINET.get(),MNDBlocks.BLACKSTONE_BRICKS_CABINET.get(),MNDBlocks.NETHER_STOVE.get());
         this.tag(BlockTags.MINEABLE_WITH_AXE).add(MNDBlocks.HOGLIN_TROPHY.get(),MNDBlocks.WAXED_HOGLIN_TROPHY.get(),MNDBlocks.ZOGLIN_TROPHY.get(),MNDBlocks.SKOGLIN_TROPHY.get(),MNDBlocks.POWDERY_CANNON.get(),MNDBlocks.POWDERY_CANE.get(),MNDBlocks.POWDERY_CHUBBY_SAPLING.get(),MNDBlocks.BULLET_PEPPER.get(),MNDBlocks.BLOCK_OF_POWDERY_CANNON.get(),MNDBlocks.BLOCK_OF_STRIPPED_POWDERY_CANNON.get(),MNDBlocks.POWDERY_MOSAIC.get(),MNDBlocks.POWDERY_MOSAIC_STAIRS.get(),MNDBlocks.POWDERY_MOSAIC_SLAB.get(),MNDBlocks.BULLET_PEPPER_CRATE.get());
-        this.tag(ModTags.MINEABLE_WITH_KNIFE).add(MNDBlocks.STUFFED_HOGLIN.get(),MNDBlocks.BREAD_LOAF_BLOCK.get(),MNDBlocks.GHASTA_WITH_CREAM_BLOCK.get(),MNDBlocks.STRIDERLOAF_BLOCK.get(),MNDBlocks.MAGMA_CAKE.get(),MNDBlocks.POWDERY_CANNON.get(),MNDBlocks.POWDERY_CANE.get(),MNDBlocks.POWDERY_CHUBBY_SAPLING.get(),MNDBlocks.BULLET_PEPPER.get());
+        this.tag(CommonTags.Blocks.MINEABLE_WITH_KNIFE).add(MNDBlocks.STUFFED_HOGLIN.get(),MNDBlocks.BREAD_LOAF_BLOCK.get(),MNDBlocks.GHASTA_WITH_CREAM_BLOCK.get(),MNDBlocks.STRIDERLOAF_BLOCK.get(),MNDBlocks.MAGMA_CAKE.get(),MNDBlocks.POWDERY_CANNON.get(),MNDBlocks.POWDERY_CANE.get(),MNDBlocks.POWDERY_CHUBBY_SAPLING.get(),MNDBlocks.BULLET_PEPPER.get());
     }
 
     protected void registerMinecraftTags() {
@@ -60,7 +61,7 @@ public class MNDBlockTags extends BlockTagsProvider {
         this.tag(BlockTags.FENCE_GATES).add(MNDBlocks.POWDERY_FENCE_GATE.get());
     }
 
-    protected void registerForgeTags() {
+    protected void registerCommonTags() {
         this.tag(BlockTags.DIRT).add(MNDBlocks.RESURGENT_SOIL.get(), MNDBlocks.RESURGENT_SOIL_FARMLAND.get());
         this.tag(BlockTags.NYLIUM).add(MNDBlocks.LETIOS_COMPOST.get(), MNDBlocks.RESURGENT_SOIL.get(), MNDBlocks.RESURGENT_SOIL_FARMLAND.get());
         this.tag(BlockTags.MUSHROOM_GROW_BLOCK).add(MNDBlocks.LETIOS_COMPOST.get(), MNDBlocks.RESURGENT_SOIL.get(), MNDBlocks.RESURGENT_SOIL_FARMLAND.get());
@@ -76,17 +77,17 @@ public class MNDBlockTags extends BlockTagsProvider {
         this.tag(MNDTags.RESURGENT_SOIL_PLANT).add(Blocks.CACTUS)
                 .addTag(MNDTags.ABOVE_PROPAGATE_PLANT).addTag(MNDTags.BELOW_PROPAGATE_PLANT).addTag(BlockTags.MINEABLE_WITH_HOE).addTag(BlockTags.SWORD_EFFICIENT);
 
-        this.tag(ModTags.TRAY_HEAT_SOURCES).add(MNDBlocks.MAGMA_CAKE.get());
-        this.tag(ModTags.HEAT_SOURCES).add(MNDBlocks.NETHER_STOVE.get(),MNDBlocks.BULLET_PEPPER_CRATE.get());
-        this.tag(ModTags.WILD_CROPS).add(MNDBlocks.BULLET_PEPPER.get());
-        this.tag(ModTags.UNAFFECTED_BY_RICH_SOIL).add(MNDBlocks.WARPED_FUNGUS_COLONY.get(),MNDBlocks.CRIMSON_FUNGUS_COLONY.get());
-        this.tag(ModTags.MUSHROOM_COLONY_GROWABLE_ON).add(MNDBlocks.RESURGENT_SOIL.get());
+        this.tag(ModTags.Blocks.TRAY_HEAT_SOURCES).add(MNDBlocks.MAGMA_CAKE.get());
+        this.tag(ModTags.Blocks.HEAT_SOURCES).add(MNDBlocks.NETHER_STOVE.get(),MNDBlocks.BULLET_PEPPER_CRATE.get());
+        this.tag(ModTags.Blocks.WILD_CROPS).add(MNDBlocks.BULLET_PEPPER.get());
+        this.tag(ModTags.Blocks.UNAFFECTED_BY_RICH_SOIL).add(MNDBlocks.WARPED_FUNGUS_COLONY.get(),MNDBlocks.CRIMSON_FUNGUS_COLONY.get());
+        this.tag(ModTags.Blocks.MUSHROOM_COLONY_GROWABLE_ON).add(MNDBlocks.RESURGENT_SOIL.get());
 
         this.tag(MNDTags.SHOWCASE_ACTIVATORS).add(Blocks.WITHER_ROSE, Blocks.SOUL_SAND, MNDBlocks.LETIOS_COMPOST.get(), MNDBlocks.RESURGENT_SOIL.get(), Blocks.NETHER_WART, Blocks.CRIMSON_FUNGUS, MNDBlocks.CRIMSON_FUNGUS_COLONY.get(), Blocks.WARPED_FUNGUS, MNDBlocks.WARPED_FUNGUS_COLONY.get(), Blocks.RED_MUSHROOM, ModBlocks.RED_MUSHROOM_COLONY.get(), Blocks.BROWN_MUSHROOM, ModBlocks.BROWN_MUSHROOM_COLONY.get(), Blocks.TWISTING_VINES, Blocks.WEEPING_VINES, Blocks.BONE_BLOCK);
         this.tag(MNDTags.SHOWCASE_FLAMES).add(Blocks.MAGMA_BLOCK,MNDBlocks.MAGMA_CAKE.get(), Blocks.LANTERN, Blocks.TORCH, MNDBlocks.POWDERY_TORCH.get(), Blocks.SOUL_TORCH, Blocks.SOUL_LANTERN,Blocks.FURNACE,Blocks.SMOKER,Blocks.BLAST_FURNACE,ModBlocks.STOVE.get(),MNDBlocks.NETHER_STOVE.get()).addTag(net.minecraft.tags.BlockTags.CAMPFIRES).addTag(BlockTags.CANDLES);
 
         this.tag(MNDTags.LETIOS_ACTIVATORS).add(Blocks.TWISTING_VINES_PLANT, Blocks.WEEPING_VINES_PLANT).addTag(MNDTags.SHOWCASE_ACTIVATORS);
-        this.tag(MNDTags.LETIOS_FLAMES).add(Blocks.LAVA_CAULDRON,MNDBlocks.POWDERY_CANE.get(),MNDBlocks.POWDERY_CANNON.get(),MNDBlocks.BULLET_PEPPER.get(),MNDBlocks.GHASTA_WITH_CREAM_BLOCK.get(),MNDBlocks.POTTED_BULLET_PEPPER.get(),MNDBlocks.WALL_POWDERY_TORCH.get(),Blocks.WALL_TORCH).addTag(MNDTags.SHOWCASE_FLAMES).addTag(ModTags.HEAT_SOURCES).addTag(BlockTags.CANDLE_CAKES).addTag(net.minecraft.tags.BlockTags.FIRE).add(Blocks.LAVA);
+        this.tag(MNDTags.LETIOS_FLAMES).add(Blocks.LAVA_CAULDRON,MNDBlocks.POWDERY_CANE.get(),MNDBlocks.POWDERY_CANNON.get(),MNDBlocks.BULLET_PEPPER.get(),MNDBlocks.GHASTA_WITH_CREAM_BLOCK.get(),MNDBlocks.POTTED_BULLET_PEPPER.get(),MNDBlocks.WALL_POWDERY_TORCH.get(),Blocks.WALL_TORCH).addTag(MNDTags.SHOWCASE_FLAMES).addTag(ModTags.Blocks.HEAT_SOURCES).addTag(BlockTags.CANDLE_CAKES).addTag(net.minecraft.tags.BlockTags.FIRE).add(Blocks.LAVA);
 
         this.tag(MNDTags.POWDERY_CANNON_PLANTABLE_ON).add(Blocks.MAGMA_BLOCK,Blocks.GRAVEL,Blocks.NETHERRACK,Blocks.CRIMSON_NYLIUM,Blocks.WARPED_FUNGUS,MNDBlocks.POWDERY_CANNON.get(),MNDBlocks.POWDERY_CHUBBY_SAPLING.get()).addTag(BlockTags.SAND).addTag(BlockTags.DIRT).addTag(BlockTags.BASE_STONE_NETHER).addTag(BlockTags.SOUL_SPEED_BLOCKS);
         this.tag(MNDTags.POWDERY_CANE).add(MNDBlocks.POWDERY_CANNON.get(),MNDBlocks.POWDERY_CANE.get());

--- a/src/main/java/com/soytutta/mynethersdelight/core/data/MNDItemTags.java
+++ b/src/main/java/com/soytutta/mynethersdelight/core/data/MNDItemTags.java
@@ -20,8 +20,8 @@ import net.minecraft.world.item.Items;
 import net.minecraft.world.level.block.Block;
 import net.minecraftforge.common.data.ExistingFileHelper;
 import vectorwing.farmersdelight.common.registry.ModItems;
-import vectorwing.farmersdelight.common.tag.ForgeTags;
 import vectorwing.farmersdelight.common.tag.ModTags;
+import vectorwing.farmersdelight.common.tag.CommonTags;
 
 import java.util.concurrent.CompletableFuture;
 
@@ -33,12 +33,12 @@ public class MNDItemTags extends ItemTagsProvider {
     protected void addTags(HolderLookup.Provider provider) {
         this.registerCommonTags();
         this.registerModTags();
-        this.registerForgeTags();
+        this.registerCommonTags();
         this.registerMinecraftTags();
         this.registerCompatibilityTags();
     }
 
-    private void registerCommonTags() {
+    private void registerMyCommonTags() {
         this.tag(MyCommonTags.FOODS_GIANT_TENTACLES).add(MNDItems.GHASTA.get());
         this.tag(MyCommonTags.FOODS_MAGMA_CUBE).add(MNDItems.MAGMA_CAKE.get(), MNDItems.MAGMA_CAKE_SLICE.get(), MNDItems.ROCK_SOUP.get(), MNDItems.BURNT_ROLL.get());
         this.tag(MyCommonTags.FOODS_RAW_STRIDER).addTag(MNDTags.STRIDER_SLICE).addTag(MNDTags.MINCED_STRIDER);
@@ -52,8 +52,8 @@ public class MNDItemTags extends ItemTagsProvider {
     }
 
     private void registerModTags() {
-        this.tag(ModTags.WOODEN_CABINETS).add(MNDItems.POWDERY_CABINET.get());
-        this.tag(ModTags.CABINETS).add(MNDItems.NETHER_BRICKS_CABINET.get());
+        this.tag(ModTags.Items.CABINETS_WOODEN).add(MNDItems.POWDERY_CABINET.get());
+        this.tag(ModTags.Items.CABINETS).add(MNDItems.NETHER_BRICKS_CABINET.get());
 
         this.tag(MNDTags.BLOCK_OF_POWDERY).add(MNDItems.BLOCK_OF_POWDERY_CANNON.get(), MNDItems.BLOCK_OF_STRIPPED_POWDERY_CANNON.get());
 
@@ -70,24 +70,23 @@ public class MNDItemTags extends ItemTagsProvider {
         this.tag(MNDTags.STRIDER_MEATS).addTag(MNDTags.STRIDER_SLICE).addTag(MNDTags.MINCED_STRIDER);
         this.tag(MNDTags.STUFFED_HOGLIN_ITEMS).add(MNDItems.ROAST_EAR.get(), MNDItems.PLATE_OF_STUFFED_HOGLIN.get(),
                 MNDItems.PLATE_OF_STUFFED_HOGLIN_HAM.get(), MNDItems.PLATE_OF_STUFFED_HOGLIN_SNOUT.get());
-        this.tag(ModTags.CABBAGE_ROLL_INGREDIENTS).add( MNDItems.STRIDER_SLICE.get(), MNDItems.MINCED_STRIDER.get(), MNDItems.HOGLIN_LOIN.get(), MNDItems.HOGLIN_SAUSAGE.get());
-        this.tag(ModTags.WOLF_PREY).add(MNDItems.MINCED_STRIDER.get(), MNDItems.HOGLIN_LOIN.get(), MNDItems.HOGLIN_SAUSAGE.get());
-        this.tag(ModTags.WILD_CROPS_ITEM).add(MNDItems.BULLET_PEPPER.get(),MNDItems.POWDER_CANNON.get());
+        this.tag(CommonTags.Items.RAW_MEAT).add(MNDItems.MINCED_STRIDER.get(), MNDItems.HOGLIN_LOIN.get(), MNDItems.HOGLIN_SAUSAGE.get());
+        this.tag(ModTags.Items.WILD_CROPS).add(MNDItems.BULLET_PEPPER.get(),MNDItems.POWDER_CANNON.get());
         this.tag(MNDTags.GHAST_MEATS).add(MNDItems.GHASMATI.get(), MNDItems.GHASTA.get());
     }
 
-    private void registerForgeTags() {
-        this.tag(ForgeTags.COOKED_EGGS).addTag(MyCommonTags.FOODS_BOILED_EGG).add(MNDItems.GOLDEN_EGG.get(), MNDItems.ENCHANTED_GOLDEN_EGG.get());;
-        this.tag(ForgeTags.EGGS).add(MNDItems.STRIDER_EGG.get());
-        this.tag(ForgeTags.PASTA_RAW_PASTA).add(MNDItems.GHASTA.get());
-        this.tag(ForgeTags.PASTA).add(MNDItems.GHASTA.get());
-        this.tag(ForgeTags.DOUGH).add(MNDItems.GHAST_DOUGH.get());
-        this.tag(ForgeTags.CROPS_RICE).add(MNDItems.GHASMATI.get());
-        this.tag(ForgeTags.GRAIN_RICE).add(MNDItems.GHASMATI.get());
-        this.tag(ForgeTags.RAW_FISHES).add(MNDItems.STRIDER_SLICE.get());
-        this.tag(ForgeTags.RAW_PORK).add(MNDItems.HOGLIN_SAUSAGE.get()).addTag(MyCommonTags.FOODS_RAW_HOGLIN);
-        this.tag(ForgeTags.COOKED_PORK).addTag(MyCommonTags.FOODS_COOKED_HOGLIN);
-        this.tag(ForgeTags.BREAD).add(MNDItems.SLICES_OF_BREAD.get(), MNDItems.TOASTS.get());
+    private void registerCommonTags() {
+        this.tag(CommonTags.Items.COOKED_EGGS).addTag(MyCommonTags.FOODS_BOILED_EGG).add(MNDItems.GOLDEN_EGG.get(), MNDItems.ENCHANTED_GOLDEN_EGG.get());;
+        this.tag(CommonTags.Items.EGGS).add(MNDItems.STRIDER_EGG.get());
+        this.tag(CommonTags.Items.PASTA_RAW_PASTA).add(MNDItems.GHASTA.get());
+        this.tag(CommonTags.Items.PASTA).add(MNDItems.GHASTA.get());
+        this.tag(CommonTags.Items.DOUGH).add(MNDItems.GHAST_DOUGH.get());
+        this.tag(CommonTags.Items.CROPS_RICE).add(MNDItems.GHASMATI.get());
+        this.tag(CommonTags.Items.GRAIN_RICE).add(MNDItems.GHASMATI.get());
+        this.tag(CommonTags.Items.RAW_FISHES).add(MNDItems.STRIDER_SLICE.get());
+        this.tag(CommonTags.Items.RAW_PORK).add(MNDItems.HOGLIN_SAUSAGE.get()).addTag(MyCommonTags.FOODS_RAW_HOGLIN);
+        this.tag(CommonTags.Items.COOKED_PORK).addTag(MyCommonTags.FOODS_COOKED_HOGLIN);
+        this.tag(CommonTags.Items.BREAD).add(MNDItems.SLICES_OF_BREAD.get(), MNDItems.TOASTS.get());
     }
 
     private void registerMinecraftTags() {

--- a/src/main/java/com/soytutta/mynethersdelight/core/data/recipes/MNDCookingRecipes.java
+++ b/src/main/java/com/soytutta/mynethersdelight/core/data/recipes/MNDCookingRecipes.java
@@ -5,6 +5,7 @@
 
 package com.soytutta.mynethersdelight.core.data.recipes;
 
+import com.soytutta.mynethersdelight.MyNethersDelight;
 import com.soytutta.mynethersdelight.common.tag.MNDTags;
 import com.soytutta.mynethersdelight.common.registry.MNDItems;
 import com.soytutta.mynethersdelight.common.tag.MyCommonTags;
@@ -14,7 +15,7 @@ import net.minecraft.world.item.crafting.Ingredient;
 import net.minecraftforge.common.Tags;
 import vectorwing.farmersdelight.client.recipebook.CookingPotRecipeBookTab;
 import vectorwing.farmersdelight.common.registry.ModItems;
-import vectorwing.farmersdelight.common.tag.ForgeTags;
+import vectorwing.farmersdelight.common.tag.CommonTags;
 import vectorwing.farmersdelight.data.builder.CookingPotRecipeBuilder;
 
 import java.util.function.Consumer;
@@ -36,32 +37,37 @@ public class MNDCookingRecipes {
                 .addIngredient(Ingredient.of(Items.WARPED_ROOTS, Items.CRIMSON_ROOTS, ModItems.STRAW.get()))
                 .unlockedByAnyIngredient(Items.CRIMSON_FUNGUS, Items.WARPED_FUNGUS, MNDItems.STRIDER_SLICE.get(), MNDItems.MINCED_STRIDER.get())
                 .setRecipeBookTab(CookingPotRecipeBookTab.MEALS)
-                .build(consumer, "mynethersdelight:cooking/strider_stew");
+                .setNamespace(MyNethersDelight.MODID)
+                .save(consumer);
         CookingPotRecipeBuilder.cookingPotRecipe(MNDItems.SPICY_NOODLE_SOUP.get(), 1, 200, 1.0F)
                 .addIngredient(MyCommonTags.FOODS_RICE_PASTA)
-                .addIngredient(ForgeTags.COOKED_EGGS)
+                .addIngredient(CommonTags.Items.COOKED_EGGS)
                 .addIngredient(MNDTags.HOT_SPICE)
                 .addIngredient(MyCommonTags.FOODS_RAW_HOGLIN)
                 .unlockedByAnyIngredient(MNDItems.GHASTA.get(), MNDItems.BULLET_PEPPER.get(), Items.PORKCHOP)
                 .setRecipeBookTab(CookingPotRecipeBookTab.MEALS)
-                .build(consumer, "mynethersdelight:cooking/spicy_noodle_soup");
+                .setNamespace(MyNethersDelight.MODID)
+                .save(consumer);
         CookingPotRecipeBuilder.cookingPotRecipe(MNDItems.TWISTED_GHASTA.get(), 1, 200, 1.0F)
                 .addIngredient(MNDItems.GHASTA.get())
                 .addIngredient(Ingredient.of(Items.WARPED_FUNGUS, Items.TWISTING_VINES),2)
                 .unlockedByAnyIngredient(MNDItems.GHASTA.get(), Items.WARPED_FUNGUS, Items.TWISTING_VINES)
                 .setRecipeBookTab(CookingPotRecipeBookTab.MEALS)
-                .build(consumer, "mynethersdelight:cooking/twisted_ghasta");
+                .setNamespace(MyNethersDelight.MODID)
+                .save(consumer);
         CookingPotRecipeBuilder.cookingPotRecipe(MNDItems.FRIES_GHASTA.get(), 1, 100, 1.0F, Items.PAPER)
                 .addIngredient(MNDItems.GHASTA.get(),2)
                 .setRecipeBookTab(CookingPotRecipeBookTab.MEALS)
-                .build(consumer, "mynethersdelight:cooking/fries_ghasta");
+                .setNamespace(MyNethersDelight.MODID)
+                .save(consumer);
         CookingPotRecipeBuilder.cookingPotRecipe(MNDItems.GIANT_TAKOYAKI.get(), 1, 200, 1.0F)
                 .addIngredient(MyCommonTags.FOODS_GIANT_TENTACLES)
                 .addIngredient(MyCommonTags.FOODS_GIANT_TENTACLES)
-                .addIngredient(ForgeTags.DOUGH)
+                .addIngredient(CommonTags.Items.DOUGH)
                 .addIngredient(ModItems.ONION.get())
                 .setRecipeBookTab(CookingPotRecipeBookTab.MEALS)
-                .build(consumer, "mynethersdelight:cooking/giant_tentacles");
+                .setNamespace(MyNethersDelight.MODID)
+                .save(consumer);
         CookingPotRecipeBuilder.cookingPotRecipe(MNDItems.SPICY_HOGLIN_STEW.get(), 1, 200, 1.0F)
                 .addIngredient(Ingredient.of(MNDItems.HOGLIN_LOIN.get(), MNDItems.HOGLIN_SAUSAGE.get(), MNDItems.ROASTED_SAUSAGE.get(), MNDItems.COOKED_LOIN.get()))
                 .addIngredient(Tags.Items.CROPS_POTATO)
@@ -69,30 +75,34 @@ public class MNDCookingRecipes {
                 .addIngredient(MNDItems.BULLET_PEPPER.get())
                 .unlockedByAnyIngredient(MNDItems.HOGLIN_LOIN.get(), MNDItems.BULLET_PEPPER.get())
                 .setRecipeBookTab(CookingPotRecipeBookTab.MEALS)
-                .build(consumer, "mynethersdelight:cooking/spicy_hoglin_stew");
+                .setNamespace(MyNethersDelight.MODID)
+                .save(consumer);
     }
     private static void cookMeals(Consumer<FinishedRecipe> consumer) {
         CookingPotRecipeBuilder.cookingPotRecipe(MNDItems.SCOTCH_EGGS.get(), 1, 200, 1.0F)
                 .addIngredient(Ingredient.of(MyCommonTags.FOODS_BOILED_EGG),2)
                 .addIngredient(Ingredient.of(ModItems.MINCED_BEEF.get(), MNDItems.HOGLIN_SAUSAGE.get()))
-                .addIngredient(ForgeTags.BREAD)
+                .addIngredient(CommonTags.Items.BREAD)
                 .unlockedByAnyIngredient(Items.EGG)
                 .setRecipeBookTab(CookingPotRecipeBookTab.MEALS)
-                .build(consumer, "mynethersdelight:cooking/scotch_eggs");
+                .setNamespace(MyNethersDelight.MODID)
+                .save(consumer);
         CookingPotRecipeBuilder.cookingPotRecipe(MNDItems.EGG_SOUP.get(), 1, 200, 1.0F)
                 .addIngredient(MyCommonTags.FOODS_BOILED_EGG)
-                .addIngredient(Ingredient.of(ForgeTags.COOKED_EGGS),2)
-                .addIngredient(ForgeTags.VEGETABLES_ONION)
+                .addIngredient(Ingredient.of(CommonTags.Items.COOKED_EGGS),2)
+                .addIngredient(CommonTags.Items.VEGETABLES_ONION)
                 .unlockedByAnyIngredient(Items.EGG)
                 .setRecipeBookTab(CookingPotRecipeBookTab.MEALS)
-                .build(consumer, "mynethersdelight:cooking/egg_soup");
+                .setNamespace(MyNethersDelight.MODID)
+                .save(consumer);
         CookingPotRecipeBuilder.cookingPotRecipe(MNDItems.DEVILED_EGG.get(), 2, 100, 1.0F)
                 .addIngredient(MyCommonTags.FOODS_BOILED_EGG)
                 .addIngredient(MNDTags.HOT_SPICE)
                 .addIngredient(Ingredient.of(MNDItems.HOGLIN_SAUSAGE.get(), ModItems.BACON.get()))
                 .unlockedByAnyIngredient(MNDItems.STRIDER_EGG.get(),MNDItems.BOILED_EGG.get())
                 .setRecipeBookTab(CookingPotRecipeBookTab.MEALS)
-                .build(consumer, "mynethersdelight:cooking/deviled_egg");
+                .setNamespace(MyNethersDelight.MODID)
+                .save(consumer);
         CookingPotRecipeBuilder.cookingPotRecipe(MNDItems.STRIDER_WITH_GRILLED_FUNGUS.get(), 1, 400, 1.0F)
                 .addIngredient(MNDItems.STRIDER_SLICE.get())
                 .addIngredient(Items.CRIMSON_FUNGUS, 1)
@@ -100,46 +110,51 @@ public class MNDCookingRecipes {
                 .addIngredient(Ingredient.of(Items.WARPED_FUNGUS, Items.CRIMSON_FUNGUS, Items.RED_MUSHROOM, Items.BROWN_MUSHROOM))
                 .unlockedByAnyIngredient(Items.CRIMSON_FUNGUS, Items.WARPED_FUNGUS, MNDItems.STRIDER_SLICE.get(), MNDItems.MINCED_STRIDER.get())
                 .setRecipeBookTab(CookingPotRecipeBookTab.MEALS)
-                .build(consumer, "mynethersdelight:cooking/strider_and_grilled_fungus");
+                .setNamespace(MyNethersDelight.MODID)
+                .save(consumer);
 
 
         CookingPotRecipeBuilder.cookingPotRecipe(MNDItems.CRIMSON_STROGANOFF.get(), 1, 400, 1.0F)
                 .addIngredient(MNDItems.MINCED_STRIDER.get())
                 .addIngredient(Items.CRIMSON_FUNGUS, 2)
-                .addIngredient(ForgeTags.MILK)
-                .addIngredient(ForgeTags.PASTA_RAW_PASTA)
+                .addIngredient(CommonTags.Items.MILK)
+                .addIngredient(CommonTags.Items.PASTA_RAW_PASTA)
                 .unlockedByAnyIngredient(MNDItems.MINCED_STRIDER.get(), Items.CRIMSON_FUNGUS)
                 .setRecipeBookTab(CookingPotRecipeBookTab.MEALS)
-                .build(consumer, "mynethersdelight:cooking/crimson_stroganoff");
+                .setNamespace(MyNethersDelight.MODID)
+                .save(consumer);
 
         CookingPotRecipeBuilder.cookingPotRecipe(MNDItems.FRIED_HOGLIN_CHOP.get(), 1, 200, 1.0F)
                 .addIngredient(MNDTags.LOIN_HOGLIN)
                 .addIngredient(Items.WHEAT)
-                .addIngredient(ForgeTags.MILK)
+                .addIngredient(CommonTags.Items.MILK)
                 .addIngredient(Tags.Items.EGGS)
                 .addIngredient(MNDItems.BULLET_PEPPER.get())
                 .unlockedByAnyIngredient(MNDItems.HOGLIN_LOIN.get(), MNDItems.BULLET_PEPPER.get())
                 .setRecipeBookTab(CookingPotRecipeBookTab.MEALS)
-                .build(consumer, "mynethersdelight:cooking/fried_hoglin_chop");
+                .setNamespace(MyNethersDelight.MODID)
+                .save(consumer);
 
         CookingPotRecipeBuilder.cookingPotRecipe(MNDItems.HOT_WINGS.get(), 1, 150, 0.35F)
-                .addIngredient(ForgeTags.RAW_CHICKEN)
+                .addIngredient(CommonTags.Items.RAW_CHICKEN)
                 .addIngredient(MNDTags.HOT_SPICE)
-                .addIngredient(ForgeTags.CROPS_ONION)
+                .addIngredient(CommonTags.Items.CROPS_ONION)
                 .unlockedByAnyIngredient(MNDItems.BULLET_PEPPER.get())
                 .setRecipeBookTab(CookingPotRecipeBookTab.MEALS)
-                .build(consumer, "mynethersdelight:cooking/hot_wings");
+                .setNamespace(MyNethersDelight.MODID)
+                .save(consumer);
 
         CookingPotRecipeBuilder.cookingPotRecipe(MNDItems.SPICY_CURRY.get(), 1, 200, 1.0F)
                 .addIngredient(MNDTags.CURRY_MEATS)
-                .addIngredient(ForgeTags.MILK)
+                .addIngredient(CommonTags.Items.MILK)
                 .addIngredient(MNDTags.HOT_SPICE)
-                .addIngredient(ForgeTags.CROPS_RICE)
-                .addIngredient(ForgeTags.VEGETABLES)
+                .addIngredient(CommonTags.Items.CROPS_RICE)
+                .addIngredient(CommonTags.Items.VEGETABLES)
                 .addIngredient(Ingredient.of(Items.PUMPKIN,ModItems.PUMPKIN_SLICE.get()))
                 .unlockedByAnyIngredient(MNDItems.BULLET_PEPPER.get())
                 .setRecipeBookTab(CookingPotRecipeBookTab.MEALS)
-                .build(consumer, "mynethersdelight:cooking/spicy_curry");
+                .setNamespace(MyNethersDelight.MODID)
+                .save(consumer);
 
         CookingPotRecipeBuilder.cookingPotRecipe(MNDItems.ROAST_STUFFED_HOGLIN.get(), 1, 700, 2.0F,Items.BOWL)
                 .addIngredient(MNDTags.HOT_SPICE)
@@ -148,7 +163,8 @@ public class MNDCookingRecipes {
                 .addIngredient(ModItems.NETHER_SALAD.get(), 2)
                 .unlockedByAnyIngredient(MNDItems.RAW_STUFFED_HOGLIN.get())
                 .setRecipeBookTab(CookingPotRecipeBookTab.MEALS)
-                .build(consumer, "mynethersdelight:cooking/roast_stuffed_hoglin");
+                .setNamespace(MyNethersDelight.MODID)
+                .save(consumer);
 
         CookingPotRecipeBuilder.cookingPotRecipe(MNDItems.CHILIDOG.get(), 1, 200, 0.35F,MNDItems.HOTDOG.get())
                 .addIngredient(MNDTags.HOT_SPICE)
@@ -156,13 +172,15 @@ public class MNDCookingRecipes {
                 .addIngredient(Items.NETHER_WART)
                 .unlockedByAnyIngredient(MNDItems.HOTDOG.get())
                 .setRecipeBookTab(CookingPotRecipeBookTab.MEALS)
-                .build(consumer, "mynethersdelight:cooking/chilidog");
+                .setNamespace(MyNethersDelight.MODID)
+                .save(consumer);
         CookingPotRecipeBuilder.cookingPotRecipe(MNDItems.SAUSAGE_AND_POTATOES.get(), 1, 200, 0.35F)
                 .addIngredient(Tags.Items.CROPS_POTATO)
                 .addIngredient(MNDItems.HOGLIN_SAUSAGE.get(), 2)
                 .unlockedByAnyIngredient(MNDItems.HOGLIN_SAUSAGE.get())
                 .setRecipeBookTab(CookingPotRecipeBookTab.MEALS)
-                .build(consumer, "mynethersdelight:cooking/sausage_and_potatoes");
+                .setNamespace(MyNethersDelight.MODID)
+                .save(consumer);
 
         CookingPotRecipeBuilder.cookingPotRecipe(MNDItems.HOT_CREAM.get(), 1, 50, 1.0F,Items.BUCKET)
                 .addIngredient(MNDTags.HOT_SPICE)
@@ -174,7 +192,8 @@ public class MNDCookingRecipes {
 
                 .unlockedByAnyIngredient(Items.LAVA_BUCKET)
                 .setRecipeBookTab(CookingPotRecipeBookTab.DRINKS)
-                .build(consumer, "mynethersdelight:cooking/hotcream");
+                .setNamespace(MyNethersDelight.MODID)
+                .save(consumer);
 
         CookingPotRecipeBuilder.cookingPotRecipe(MNDItems.ROCK_SOUP.get(), 1, 50, 0.35F)
                 .addIngredient(Items.MAGMA_CREAM,2)
@@ -182,13 +201,15 @@ public class MNDCookingRecipes {
 
                 .unlockedByAnyIngredient(Items.MAGMA_CREAM)
                 .setRecipeBookTab(CookingPotRecipeBookTab.MEALS)
-                .build(consumer, "mynethersdelight:cooking/rock_soup");
+                .setNamespace(MyNethersDelight.MODID)
+                .save(consumer);
         CookingPotRecipeBuilder.cookingPotRecipe(MNDItems.BURNT_ROLL.get(), 2, 50, 0.35F)
                 .addIngredient(Items.MAGMA_CREAM,2)
                 .addIngredient(MNDTags.CURRY_MEATS)
 
                 .unlockedByAnyIngredient(Items.MAGMA_CREAM)
                 .setRecipeBookTab(CookingPotRecipeBookTab.MISC)
-                .build(consumer, "mynethersdelight:cooking/burn_roll");
+                .setNamespace(MyNethersDelight.MODID)
+                .save(consumer);
     }
 }

--- a/src/main/java/com/soytutta/mynethersdelight/core/data/recipes/MNDCraftingRecipes.java
+++ b/src/main/java/com/soytutta/mynethersdelight/core/data/recipes/MNDCraftingRecipes.java
@@ -20,7 +20,7 @@ import net.minecraftforge.common.Tags;
 import vectorwing.farmersdelight.common.registry.ModBlocks;
 import vectorwing.farmersdelight.common.registry.ModItems;
 import vectorwing.farmersdelight.common.registry.ModRecipeSerializers;
-import vectorwing.farmersdelight.common.tag.ForgeTags;
+import vectorwing.farmersdelight.common.tag.CommonTags;
 
 import java.util.function.Consumer;
 
@@ -64,7 +64,7 @@ public class MNDCraftingRecipes {
                 .define('#',(Ingredient.of(ModItems.CANVAS.get(), Items.STRING)))
                 .unlockedBy("has_powder_cannon_or_canvas", InventoryChangeTrigger.TriggerInstance.hasItems(MNDItems.POWDER_CANNON.get(),ModItems.CANVAS.get()))
                 .save(consumer, new ResourceLocation( "mynethersdelight:crafting/scaffolding_alt"));
-        ShapedRecipeBuilder.shaped(RecipeCategory.MISC,ModBlocks.BASKET.get())
+        ShapedRecipeBuilder.shaped(RecipeCategory.MISC,ModBlocks.BAMBOO_BASKET.get())
                 .pattern("B b")
                 .pattern("# #")
                 .pattern("b#B")
@@ -306,7 +306,7 @@ public class MNDCraftingRecipes {
                 .save(consumer, new ResourceLocation( "mynethersdelight:crafting/bleeding_tartar"));
         ShapelessRecipeBuilder.shapeless(RecipeCategory.MISC,MNDItems.HOTDOG.get())
                 .requires(MNDItems.ROASTED_SAUSAGE.get())
-                .requires(ForgeTags.BREAD)
+                .requires(CommonTags.Items.BREAD)
                 .unlockedBy("has_sausage", InventoryChangeTrigger.TriggerInstance.hasItems(MNDItems.HOGLIN_SAUSAGE.get()))
                 .save(consumer, new ResourceLocation( "mynethersdelight:crafting/hotdog"));
         ShapelessRecipeBuilder.shapeless(RecipeCategory.MISC,MNDItems.HOTDOG_WITH_MIXED_SALAD.get(),2)
@@ -335,7 +335,7 @@ public class MNDCraftingRecipes {
                 .group("blue_tenderloin_steak_group")
                 .save(consumer, new ResourceLocation( "mynethersdelight:crafting/blue_tenderloin_steak"));
         ShapelessRecipeBuilder.shapeless(RecipeCategory.MISC,MNDItems.NETHER_BURGER.get())
-                .requires(ForgeTags.BREAD)
+                .requires(CommonTags.Items.BREAD)
                 .requires(MNDTags.COOKED_HOGLIN_LOIN)
                 .requires(Items.TWISTING_VINES)
                 .requires(Items.CRIMSON_FUNGUS)
@@ -358,9 +358,9 @@ public class MNDCraftingRecipes {
         ShapelessRecipeBuilder.shapeless(RecipeCategory.MISC,MNDItems.BREAKFAST_SAMPLER.get())
                 .requires(MNDItems.ROASTED_SAUSAGE.get(),2)
                 .requires(Ingredient.of(Items.HONEY_BOTTLE, MNDItems.STRIDER_EGG.get()))
-                .requires(ForgeTags.COOKED_EGGS)
-                .requires(ForgeTags.COOKED_EGGS)
-                .requires(ForgeTags.BREAD)
+                .requires(CommonTags.Items.COOKED_EGGS)
+                .requires(CommonTags.Items.COOKED_EGGS)
+                .requires(CommonTags.Items.BREAD)
                 .requires(Items.BOWL)
                 .unlockedBy("has_sausage", InventoryChangeTrigger.TriggerInstance.hasItems(MNDItems.ROASTED_SAUSAGE.get()))
                 .save(consumer, new ResourceLocation( "mynethersdelight:crafting/breakfast_sampler"));
@@ -375,8 +375,8 @@ public class MNDCraftingRecipes {
 
         ShapelessRecipeBuilder.shapeless(RecipeCategory.MISC,MNDItems.STUFFED_PEPPER.get())
                 .requires(MNDItems.BULLET_PEPPER.get())
-                .requires(ForgeTags.COOKED_PORK)
-                .requires(ForgeTags.MILK)
+                .requires(CommonTags.Items.COOKED_PORK)
+                .requires(CommonTags.Items.MILK)
                 .unlockedBy("has_pepper", InventoryChangeTrigger.TriggerInstance.hasItems(MNDItems.BULLET_PEPPER.get()))
                 .save(consumer, new ResourceLocation( "mynethersdelight:crafting/stuffed_pepper"));
 
@@ -407,13 +407,13 @@ public class MNDCraftingRecipes {
                 .save(consumer, new ResourceLocation( "mypersonaldelight:crafting/tear_popsicle"));
         ShapelessRecipeBuilder.shapeless(RecipeCategory.MISC,MNDItems.DRIED_GHAST_WITH_MILK.get())
                 .requires(MNDItems.GHASMATI.get())
-                .requires(ForgeTags.MILK)
+                .requires(CommonTags.Items.MILK)
                 .requires(Items.BOWL)
                 .unlockedBy("has_ghasmati", InventoryChangeTrigger.TriggerInstance.hasItems(MNDItems.GHASMATI.get()))
                 .save(consumer, new ResourceLocation( "mynethersdelight:crafting/dried_ghast_with_milk"));
         ShapelessRecipeBuilder.shapeless(RecipeCategory.MISC,MNDItems.SIZZLING_PUDDING.get())
                 .requires(MNDItems.GHASMATI.get())
-                .requires(ForgeTags.MILK)
+                .requires(CommonTags.Items.MILK)
                 .requires(Tags.Items.EGGS)
                 .requires(Items.BLAZE_POWDER)
                 .requires(Items.BOWL)
@@ -444,15 +444,15 @@ public class MNDCraftingRecipes {
                 .save(consumer, new ResourceLocation( "mynethersdelight:crafting/ghast_dough"));
         ShapelessRecipeBuilder.shapeless(RecipeCategory.MISC,MNDItems.GHAST_SOURDOUGH.get())
                 .requires(MNDItems.GHAST_DOUGH.get())
-                .requires(ForgeTags.DOUGH)
-                .requires(ForgeTags.DOUGH)
-                .requires(ForgeTags.DOUGH)
+                .requires(CommonTags.Items.DOUGH)
+                .requires(CommonTags.Items.DOUGH)
+                .requires(CommonTags.Items.DOUGH)
                 .unlockedBy("has_ghast", InventoryChangeTrigger.TriggerInstance.hasItems(MNDItems.GHASMATI.get(),MNDItems.GHASTA.get()))
                 .save(consumer, new ResourceLocation( "mynethersdelight:crafting/ghast_sourdough"));
 
         ShapelessRecipeBuilder.shapeless(RecipeCategory.MISC,MNDItems.GHAST_SALAD.get())
                 .requires(MyCommonTags.FOODS_RAW_GHAST)
-                .requires(ForgeTags.VEGETABLES)
+                .requires(CommonTags.Items.VEGETABLES)
                 .requires(Tags.Items.CROPS_CARROT)
                 .requires(Items.BOWL)
                 .unlockedBy("has_ghast", InventoryChangeTrigger.TriggerInstance.hasItems(MNDItems.GHASMATI.get(),MNDItems.GHASTA.get()))

--- a/src/main/java/com/soytutta/mynethersdelight/core/data/recipes/MNDCuttingRecipes.java
+++ b/src/main/java/com/soytutta/mynethersdelight/core/data/recipes/MNDCuttingRecipes.java
@@ -5,6 +5,7 @@
 
 package com.soytutta.mynethersdelight.core.data.recipes;
 
+import com.soytutta.mynethersdelight.MyNethersDelight;
 import com.soytutta.mynethersdelight.common.registry.MNDItems;
 import net.minecraft.data.recipes.FinishedRecipe;
 import net.minecraft.sounds.SoundEvents;
@@ -15,7 +16,7 @@ import net.minecraftforge.common.ToolActions;
 import net.minecraftforge.registries.ForgeRegistries;
 import vectorwing.farmersdelight.common.crafting.ingredient.ToolActionIngredient;
 import vectorwing.farmersdelight.common.registry.ModItems;
-import vectorwing.farmersdelight.common.tag.ForgeTags;
+import vectorwing.farmersdelight.common.tag.CommonTags;
 import vectorwing.farmersdelight.data.builder.CuttingBoardRecipeBuilder;
 
 import java.util.Objects;
@@ -35,53 +36,62 @@ public class MNDCuttingRecipes {
 
     private static void cuttingAnimalItems(Consumer<FinishedRecipe> consumer) {
         CuttingBoardRecipeBuilder.cuttingRecipe(Ingredient.of(MNDItems.GHASTA.get()),
-                        Ingredient.of(ForgeTags.TOOLS_KNIVES),
+                        Ingredient.of(CommonTags.Items.TOOLS_KNIVES),
                         MNDItems.GHASMATI.get())
                 .addResultWithChance(MNDItems.GHASMATI.get(), 0.05F)
-                .build(consumer, "mynethersdelight:cutting/ghasmati");
+                .setNamespace(MyNethersDelight.MODID)
+                .save(consumer);
         CuttingBoardRecipeBuilder.cuttingRecipe(Ingredient.of(MNDItems.STRIDER_ROCK.get()),
-                        Ingredient.of(ForgeTags.TOOLS_PICKAXES),
+                        Ingredient.of(CommonTags.Items.TOOLS_PICKAXES),
                         MNDItems.STRIDER_EGG.get())
                 .addResultWithChance(Items.BONE_MEAL, 0.25F)
-                .build(consumer, "mynethersdelight:cutting/strider_egg");
+                .setNamespace(MyNethersDelight.MODID)
+                .save(consumer);
         CuttingBoardRecipeBuilder.cuttingRecipe(Ingredient.of(MNDItems.STRIDER_SLICE.get()),
-                        Ingredient.of(ForgeTags.TOOLS_KNIVES),
+                        Ingredient.of(CommonTags.Items.TOOLS_KNIVES),
                         MNDItems.MINCED_STRIDER.get(), 2)
                 .addResult(Items.STRING)
                 .addResultWithChance(Items.STRING, 0.5F, 2)
-                .build(consumer, "mynethersdelight:cutting/minced_strider");
+                .setNamespace(MyNethersDelight.MODID)
+                .save(consumer);
         CuttingBoardRecipeBuilder.cuttingRecipe(Ingredient.of(MNDItems.HOGLIN_LOIN.get()),
-                        Ingredient.of(ForgeTags.TOOLS_KNIVES),
+                        Ingredient.of(CommonTags.Items.TOOLS_KNIVES),
                         MNDItems.HOGLIN_SAUSAGE.get(), 2)
-                .build(consumer, "mynethersdelight:cutting/hoglin_sausage");
+                .setNamespace(MyNethersDelight.MODID)
+                .save(consumer);
         CuttingBoardRecipeBuilder.cuttingRecipe(Ingredient.of(MNDItems.HOGLIN_HIDE.get())
-                        , Ingredient.of(ForgeTags.TOOLS_KNIVES),
+                        , Ingredient.of(CommonTags.Items.TOOLS_KNIVES),
                         Items.LEATHER, 4)
                 .addResultWithChance(Items.LEATHER, 0.5F, 2)
-                .build(consumer, "mynethersdelight:cutting/hoglin_hide");
+                .setNamespace(MyNethersDelight.MODID)
+                .save(consumer);
         CuttingBoardRecipeBuilder.cuttingRecipe(Ingredient.of(Items.BLAZE_ROD),
-                        Ingredient.of(ForgeTags.TOOLS_KNIVES),
+                        Ingredient.of(CommonTags.Items.TOOLS_KNIVES),
                         Items.BLAZE_POWDER, 3)
                 .addResultWithChance(Items.BLAZE_POWDER, 0.25F, 1)
-                .build(consumer, "mynethersdelight:cutting/balze_rod");
+                .setNamespace(MyNethersDelight.MODID)
+                .save(consumer);
 
         CuttingBoardRecipeBuilder.cuttingRecipe(Ingredient.of(MNDItems.HOGLIN_TROPHY.get()),
-                        Ingredient.of(ForgeTags.TOOLS_KNIVES),
+                        Ingredient.of(CommonTags.Items.TOOLS_KNIVES),
                         MNDItems.SKOGLIN_TROPHY.get())
                 .addResult(Items.LEATHER)
                 .addResultWithChance(Items.LEATHER, 0.5F, 2)
-                .build(consumer, "mynethersdelight:cutting/skoglin_trophy");
+                .setNamespace(MyNethersDelight.MODID)
+                .save(consumer);
         CuttingBoardRecipeBuilder.cuttingRecipe(Ingredient.of(MNDItems.ZOGLIN_TROPHY.get()),
-                        Ingredient.of(ForgeTags.TOOLS_KNIVES),
+                        Ingredient.of(CommonTags.Items.TOOLS_KNIVES),
                         MNDItems.SKOGLIN_TROPHY.get())
                 .addResult(Items.ROTTEN_FLESH)
                 .addResultWithChance(Items.ROTTEN_FLESH, 0.5F, 2)
-                .build(consumer, "mynethersdelight:cutting/skoglin_trophy_alt");
+                .setNamespace(MyNethersDelight.MODID)
+                .save(consumer);
 
         CuttingBoardRecipeBuilder.cuttingRecipe(Ingredient.of(MNDItems.WAXED_HOGLIN_TROPHY.get()),
-                        Ingredient.of(ForgeTags.TOOLS_AXES),
+                        Ingredient.of(CommonTags.Items.TOOLS_AXES),
                         MNDItems.HOGLIN_TROPHY.get())
-                .build(consumer, "mynethersdelight:cutting/hoglin_trophy");
+                .setNamespace(MyNethersDelight.MODID)
+                .save(consumer);
     }
     private static void strippingWood(Consumer<FinishedRecipe> consumer) {
         stripLogForBark(consumer, MNDItems.BLOCK_OF_POWDERY_CANNON.get(), MNDItems.BLOCK_OF_STRIPPED_POWDERY_CANNON.get());
@@ -93,57 +103,67 @@ public class MNDCuttingRecipes {
 
     private static void cuttingVegetables(Consumer<FinishedRecipe> consumer) {
         CuttingBoardRecipeBuilder.cuttingRecipe(Ingredient.of(Items.SUGAR_CANE),
-                        Ingredient.of(ForgeTags.TOOLS_KNIVES),
+                        Ingredient.of(CommonTags.Items.TOOLS_KNIVES),
                         Items.SUGAR, 1)
                 .addResultWithChance(Items.SUGAR, 0.25F, 1)
-                .build(consumer, "farmersdelight:cutting/sugar_cane_alt");
+                .setNamespace(MyNethersDelight.MODID)
+                .save(consumer);
         CuttingBoardRecipeBuilder.cuttingRecipe(Ingredient.of(Items.CARVED_PUMPKIN),
-                        Ingredient.of(ForgeTags.TOOLS_KNIVES),
+                        Ingredient.of(CommonTags.Items.TOOLS_KNIVES),
                         ModItems.PUMPKIN_SLICE.get(), 1)
                 .addResultWithChance(Items.PUMPKIN_SEEDS, 0.25F, 1)
-                .build(consumer, "farmersdelight:cutting/pumpkin_slice_alt");
+                .setNamespace(MyNethersDelight.MODID)
+                .save(consumer);
         CuttingBoardRecipeBuilder.cuttingRecipe(Ingredient.of(MNDItems.POWDER_CANNON.get()),
-                        Ingredient.of(ForgeTags.TOOLS_KNIVES),
+                        Ingredient.of(CommonTags.Items.TOOLS_KNIVES),
                         Items.GUNPOWDER, 1)
                 .addResultWithChance(Items.GUNPOWDER, 0.25F, 1)
-                .build(consumer, "mynethersdelight:cutting/gunpowder_cane");
+                .setNamespace(MyNethersDelight.MODID)
+                .save(consumer);
         CuttingBoardRecipeBuilder.cuttingRecipe(Ingredient.of(MNDItems.BULLET_PEPPER.get()),
-                        Ingredient.of(ForgeTags.TOOLS_KNIVES),
+                        Ingredient.of(CommonTags.Items.TOOLS_KNIVES),
                         Items.BLAZE_POWDER, 1)
                 .addResultWithChance(Items.BLAZE_POWDER, 0.25F, 1)
-                .build(consumer, "mynethersdelight:cutting/bullet_pepper");
+                .setNamespace(MyNethersDelight.MODID)
+                .save(consumer);
         CuttingBoardRecipeBuilder.cuttingRecipe(Ingredient.of(MNDItems.CRIMSON_FUNGUS_COLONY.get()),
-                        Ingredient.of(ForgeTags.TOOLS_KNIVES),
+                        Ingredient.of(CommonTags.Items.TOOLS_KNIVES),
                         Items.CRIMSON_FUNGUS, 5)
-                .build(consumer, "mynethersdelight:cutting/crimson_fungus");
+                .setNamespace(MyNethersDelight.MODID)
+                .save(consumer);
         CuttingBoardRecipeBuilder.cuttingRecipe(Ingredient.of(MNDItems.WARPED_FUNGUS_COLONY.get()),
-                        Ingredient.of(ForgeTags.TOOLS_KNIVES),
+                        Ingredient.of(CommonTags.Items.TOOLS_KNIVES),
                         Items.WARPED_FUNGUS, 5)
-                .build(consumer, "mynethersdelight:cutting/warped_fungus");
+                .setNamespace(MyNethersDelight.MODID)
+                .save(consumer);
     }
 
     private static void cuttingFoods(Consumer<FinishedRecipe> consumer) {
         CuttingBoardRecipeBuilder.cuttingRecipe(Ingredient.of(MNDItems.MAGMA_CAKE.get()),
-                        Ingredient.of(ForgeTags.TOOLS_KNIVES),
+                        Ingredient.of(CommonTags.Items.TOOLS_KNIVES),
                         MNDItems.MAGMA_CAKE_SLICE.get(), 7)
-                .build(consumer, "mynethersdelight:cutting/magma_cake");
+                .setNamespace(MyNethersDelight.MODID)
+                .save(consumer);
         CuttingBoardRecipeBuilder.cuttingRecipe(Ingredient.of(MNDItems.BREAD_LOAF_BLOCK.get()),
-                        Ingredient.of(ForgeTags.TOOLS_KNIVES),
+                        Ingredient.of(CommonTags.Items.TOOLS_KNIVES),
                         MNDItems.SLICES_OF_BREAD.get(), 5)
-                .build(consumer, "mynethersdelight:cutting/slices_of_bread");
+                .setNamespace(MyNethersDelight.MODID)
+                .save(consumer);
         CuttingBoardRecipeBuilder.cuttingRecipe(Ingredient.of(MNDItems.GHAST_SOURDOUGH.get()),
-                        Ingredient.of(ForgeTags.TOOLS_KNIVES),
+                        Ingredient.of(CommonTags.Items.TOOLS_KNIVES),
                         MNDItems.GHAST_DOUGH.get(), 3)
-                .build(consumer, "mynethersdelight:cutting/ghast_dough");
+                .setNamespace(MyNethersDelight.MODID)
+                .save(consumer);
     }
 
     private static void stripLogForBark(Consumer<FinishedRecipe> consumer, ItemLike log, ItemLike strippedLog) {
-        CuttingBoardRecipeBuilder.cuttingRecipe(Ingredient.of(log), new ToolActionIngredient(ToolActions.AXE_STRIP), strippedLog).addResult(ModItems.STRAW.get()).addSound(Objects.requireNonNull(ForgeRegistries.SOUND_EVENTS.getKey(SoundEvents.AXE_STRIP)).toString()).build(consumer);
+        CuttingBoardRecipeBuilder.cuttingRecipe(Ingredient.of(log), new ToolActionIngredient(ToolActions.AXE_STRIP), strippedLog).addResult(ModItems.STRAW.get()).addSound(Objects.requireNonNull(ForgeRegistries.SOUND_EVENTS.getKey(SoundEvents.AXE_STRIP)).toString()).setNamespace(MyNethersDelight.MODID)
+                .save(consumer);
     }
 
     private static void salvagePlankFromFurniture(Consumer<FinishedRecipe> consumer, ItemLike plank, ItemLike door, ItemLike trapdoor, ItemLike sign) {
-        CuttingBoardRecipeBuilder.cuttingRecipe(Ingredient.of(door), new ToolActionIngredient(ToolActions.AXE_DIG), plank).build(consumer);
-        CuttingBoardRecipeBuilder.cuttingRecipe(Ingredient.of(trapdoor), new ToolActionIngredient(ToolActions.AXE_DIG), plank).build(consumer);
-        CuttingBoardRecipeBuilder.cuttingRecipe(Ingredient.of(sign), new ToolActionIngredient(ToolActions.AXE_DIG), plank).build(consumer);
+        CuttingBoardRecipeBuilder.cuttingRecipe(Ingredient.of(door), new ToolActionIngredient(ToolActions.AXE_DIG), plank).setNamespace(MyNethersDelight.MODID).save(consumer);
+        CuttingBoardRecipeBuilder.cuttingRecipe(Ingredient.of(trapdoor), new ToolActionIngredient(ToolActions.AXE_DIG), plank).setNamespace(MyNethersDelight.MODID).save(consumer);
+        CuttingBoardRecipeBuilder.cuttingRecipe(Ingredient.of(sign), new ToolActionIngredient(ToolActions.AXE_DIG), plank).setNamespace(MyNethersDelight.MODID).save(consumer);
     }
 }


### PR DESCRIPTION
Migrates MND to use the new `CommonTags` and `.Blocks`/`.Items` subcategories of Farmers Delight 1.3, and updates the broken function reference from the Nether Stove block entity.
This fixes #143 and #142.
This may fix #140 and #131.